### PR TITLE
Fixes skipped processes for nonlocal refs

### DIFF
--- a/modules/classify_taxonomy.nf
+++ b/modules/classify_taxonomy.nf
@@ -183,26 +183,26 @@ process COMBINE_FEATURE_TABLES {
 }
 
 process DOWNLOAD_CLASSIFIER {
+    input:
+    val(flag)
+
     output:
     path "classifier.qza"
-
-    when:
-    flag_get_classifier
 
     script:
     """
     echo 'Downloading default taxonomy feature classifier...'
 
-    wget -O classifier.qza ${params.classifier_url}
+    wget -O classifier.qza ${params.trained_classifier_url}
     """
 }
 
 process DOWNLOAD_REF_TAXONOMY {
+    input:
+    val(flag)
+
     output:
     path "ref_taxonomy.qza"
-
-    when:
-    flag_get_ref_taxa
 
     script:
     """

--- a/modules/cluster_vsearch.nf
+++ b/modules/cluster_vsearch.nf
@@ -36,11 +36,11 @@ process CLUSTER_CLOSED_OTU {
 }
 
 process DOWNLOAD_REF_SEQS {
+    input:
+    val(flag)
+
     output:
     path "ref_seqs.qza"
-
-    when:
-    flag_get_ref
 
     script:
     """

--- a/workflows/pipe_16s.nf
+++ b/workflows/pipe_16s.nf
@@ -202,7 +202,7 @@ workflow PIPE_16S {
 
     // Feature generation: Clustering
     if (flag_get_ref) {
-        DOWNLOAD_REF_SEQS ()
+        DOWNLOAD_REF_SEQS ( flag_get_ref )
         ch_otu_ref_qza = DOWNLOAD_REF_SEQS.out
     }
 
@@ -238,12 +238,12 @@ workflow PIPE_16S {
 
     // Classification
     if (flag_get_classifier) {
-        DOWNLOAD_CLASSIFIER ()
+        DOWNLOAD_CLASSIFIER ( flag_get_classifier )
         ch_trained_classifier = DOWNLOAD_CLASSIFIER.out
     }
 
     if (flag_get_ref_taxa) {
-        DOWNLOAD_REF_TAXONOMY ()
+        DOWNLOAD_REF_TAXONOMY ( flag_get_ref_taxa )
         ch_taxa_ref_qza = DOWNLOAD_REF_TAXONOMY.out
     }
 


### PR DESCRIPTION
Closes #67. When no local reference files were given for closed-reference OTU clustering or feature classification, the workflow initially skipped all of these processes -- sometimes halting the entire workflow. For some reason, removing the `when` directive from these processes did the trick.