### PR TITLE
ENH: Export more ouputs of plugins to the outDir(/stats/) directory.

### DIFF
--- a/modules/classify_taxonomy.nf
+++ b/modules/classify_taxonomy.nf
@@ -105,13 +105,13 @@ process CLASSIFY_TAXONOMY {
 process COLLAPSE_TAXA {
     label "container_qiime2"
     tag "${sample_id}"
-    publishDir "${params.outdir}/stats/collapsed_taxa_tables/", pattern: "*_collapsed_table.qza"
+    publishDir "${params.outdir}/stats/collapsed_taxa_tables/", pattern: "*_collapsed_${params.taxa_level}_table.qza"
     
     input:
     tuple val(sample_id), path(table), path(taxonomy)
 
     output:
-    path "${sample_id}_collapsed_table.qza"
+    path "${sample_id}_collapsed_${params.taxa_level}_table.qza"
 
     script:
     """
@@ -121,7 +121,7 @@ process COLLAPSE_TAXA {
         --i-table ${table} \
         --i-taxonomy ${taxonomy} \
         --p-level ${params.taxa_level} \
-        --o-collapsed-table ${sample_id}_collapsed_table.qza \
+        --o-collapsed-table ${sample_id}_collapsed_${params.taxa_level}_table.qza \
         --verbose
     """
 }

--- a/modules/cluster_vsearch.nf
+++ b/modules/cluster_vsearch.nf
@@ -55,7 +55,7 @@ process FIND_CHIMERAS {
     label "container_qiime2"
     label "process_local"
     tag "${sample_id}"
-    publishDir "${params.outdir}/stats/find_chimeras_stats/", pattern: "*_stats.qza"
+    publishDir "${params.outdir}/stats/chimera_checking_stats/", pattern: "*_chimera_checking_summary.qza"
 
     afterScript "rm -rf \${PWD}/tmp_chimera"
 
@@ -65,7 +65,7 @@ process FIND_CHIMERAS {
     output:
     tuple val(sample_id), path("${sample_id}_nonchimeras.qza"), emit: nonchimeras
     path "${sample_id}_chimeras.qza",                           emit: chimeras
-    path "${sample_id}_stats.qza",                              emit: stats
+    path "${sample_id}_chimera_checking_summary.qza",                              emit: stats
 
     when:
     params.vsearch_chimera
@@ -89,7 +89,7 @@ process FIND_CHIMERAS {
         --p-threads ${params.uchime_ref.num_threads} \
         --o-chimeras ${sample_id}_chimeras.qza \
         --o-nonchimeras ${sample_id}_nonchimeras.qza \
-        --o-stats ${sample_id}_stats.qza \
+        --o-stats ${sample_id}_chimera_checking_summary.qza \
         --verbose
     """
 }
@@ -97,7 +97,7 @@ process FIND_CHIMERAS {
 process FILTER_CHIMERAS {
     label "container_qiime2"
     tag "${sample_id}"
-    publishDir "${params.outdir}/stats/filtered_chimeras_tables/", pattern: "*.qzv"
+    publishDir "${params.outdir}/stats/chimera_checking_stats/", pattern: "*.qzv"
 
     afterScript "rm -rf \${PWD}/tmp_filt"
 
@@ -106,7 +106,7 @@ process FILTER_CHIMERAS {
 
     output:
     tuple val(sample_id), path("${sample_id}_table_filt_chimera.qza"), path("${sample_id}_seqs_filt_chimera.qza"), emit: filt_qzas
-    path "${sample_id}_table_filt_chimera.qzv", emit: viz_table
+    path "${sample_id}_chimera_free_table.qzv", emit: viz_table
 
     when:
     params.vsearch_chimera
@@ -130,6 +130,6 @@ process FILTER_CHIMERAS {
 
     qiime feature-table summarize \
         --i-table ${sample_id}_table_filt_chimera.qza \
-        --o-visualization ${sample_id}_table_filt_chimera.qzv
+        --o-visualization ${sample_id}_chimera_free_table.qzv
     """
 }

--- a/modules/denoise_dada2.nf
+++ b/modules/denoise_dada2.nf
@@ -4,7 +4,7 @@ process DENOISE_DADA2 {
     label "error_retry"
     tag "${sample_id}"
 
-    publishDir "${params.outdir}/stats/", pattern: "*_stats.qza"
+    publishDir "${params.outdir}/stats/denoising_stats/", pattern: "*_stats.qza"
     afterScript "rm -rf \${PWD}/tmp_denoise"
 
     input:

--- a/modules/quality_control.nf
+++ b/modules/quality_control.nf
@@ -41,7 +41,7 @@ process RUN_FASTQC {
 
 process CUTADAPT_TRIM {
     label "container_qiime2"
-    publishDir "${params.outdir}/stats/", pattern: "*.log"
+    publishDir "${params.outdir}/stats/trimming_logs/", pattern: "*.log"
 
     input:
     tuple path(demux_qza), val(primer_id), val(primer_seq_fwd), val(primer_seq_rev)


### PR DESCRIPTION
Exports more plugin outputs to the outDir directory. For example, we output the _collapsed_table.qza files from COLLAPSE_TAXA process. Also, we better organize the output files of the workflow processes by adding subdirectories under the stats directory.