### PR TITLE
BUG: Remove conda environments directories after workflow completion

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -54,7 +54,6 @@ workflow {
 }
 
 workflow.onComplete {
-    print(workflow.profile )
     if (workflow.profile.contains('conda')) {
         println("Workflow completed. Cleaning up Conda environments...")
 


### PR DESCRIPTION
This fix introduces an automated cleanup step for removing Conda environments in our Nextflow workflow, activated only when using the 'conda' profile. It uses workflow.onComplete to ensure cleanup happens post-execution, employing rm -rf work/conda/ for environment removal. 