### PR TITLE
FIX: Wait for all the outputs of Cutadapt before applying MultiQC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Required if running from local FASTQ files:
 * `fastq_manifest`: Path to TSV file mapping sample identifiers to FASTQ absolute file paths; manifest must adhere to [QIIME 2 FASTQ manifest formatting requirements](https://docs.qiime2.org/2022.2/tutorials/importing/#fastq-manifest-formats)
 
 Required if running Cutadapt:
-* `primer_file`: Path to TSV file containing forward (and, if applicable, reverse) primers. Each row represents a different primer pair.
 * For primer removal:
-  * If single-end, one of the following `cutadapt.adapter`, `cutadapt.front`, and `cutadapt.anywhere`: Primer sequence to remove; `cutadapt.front` is recommended for most amplicon sequence runs.
-  * If paired-end, one of the following pairs `cutadapt.adapter_f`/`cutadapt.adapter_r`, `cutadapt.front_f`/`cutadapt.front_r`, or `cutadapt.anywhere_f`/`cutadapt.anywhere_r`: Primer sequences to remove; `cutadapt.front_f`/`cutadapt.front_r` are recommended for most amplicon sequence runs.
+  * If single-end, `cutadapt.front`: Primer sequence to remove; multiple primers are delimited by a space.
+  * If paired-end, `cutadapt.front_f`/`cutadapt.front_r`: Primer sequences to remove; multiple primers are delimited by a space.
+  * Note that `cutadapt.front` is recommended for most amplicon sequence runs, and `cutadapt.adapter` and `cutadapt.anywhere` are not supported in this workflow. The same goes for their paired counterparts.
   * The workflow does not at the moment support linked primers. Additionally, the workflow currently only takes a collection of single-end or paired-end primers, but not a combination of both.
 
 ### Bypassing parameter validation:
@@ -77,17 +77,6 @@ Cutadapt process parameters in scope `params.cutadapt`:
 * `quality_cutoff_5end`: default `0`
 * `quality_cutoff_3end`: default `0`
 * `quality_base`: default `33`
-* Parameters for **single-end runs**:
-  * `adapter`: default `null`
-  * `front`: default `null`
-  * `anywhere`: default `null`
-* Parameters for **paired-end runs**:
-  * `adapter_f`: default `null`
-  * `front_f`: default `null`
-  * `anywhere_f`: default `null`
-  * `adapter_r`: default `null`
-  * `front_r`: default `null`
-  * `anywhere_r`: default `null`
 
 DADA2 process parameters in scope `params.dada2`:
 * `trunc_q`: default `2`

--- a/bin/split_manifest.py
+++ b/bin/split_manifest.py
@@ -147,6 +147,12 @@ def arg_parse():
         type=str,
         required=True,
     )
+    parser.add_argument(
+        "--suffix",
+        help="Optional suffix to add to each split manifest.",
+        type=str,
+        required=True,
+    )
 
     # Optional user-input arguments
     parser.add_argument(
@@ -156,12 +162,7 @@ def arg_parse():
         type=str,
         default=Path.cwd(),
     )
-    parser.add_argument(
-        "--suffix",
-        help="Optional suffix to add to each split manifest.",
-        type=str,
-        default="_split.tsv",
-    )
+
     parser.add_argument(
         "--split_method",
         help="Method to split input manifest. Options include 'sample' or an "
@@ -176,14 +177,17 @@ def arg_parse():
 
 def main(args):
     assert Path(args.input_manifest).is_file()
-    assert Path(args.output_dir).is_dir()
     assert args.split_method == "sample" or args.split_method.isdigit()
+    if Path(args.output_dir).resolve() != Path.cwd().resolve():
+        assert not Path(args.output_dir).is_dir(), f"The directory " \
+                                                   f"{args.output_dir} already " \
+                                                   f"exists. Exiting..."
+        Path.mkdir(args.output_dir)
 
     try:
         manifest_df = pd.read_csv(args.input_manifest, sep="\t")
         manifest_df.dropna(inplace=True)
         assert len(manifest_df.columns) == manifest_df.shape[1]
-        assert len(manifest_df.columns) > 1
         assert len(manifest_df.index) > 0
 
     except FileNotFoundError:

--- a/modules/denoise_dada2.nf
+++ b/modules/denoise_dada2.nf
@@ -2,17 +2,17 @@ process DENOISE_DADA2 {
     label "container_qiime2"
     label "process_local"
     label "error_retry"
-    tag "${sample_id}"
+    tag "${set_id}"
 
     publishDir "${params.outdir}/stats/denoising_stats/", pattern: "*_stats.qza"
     afterScript "rm -rf \${PWD}/tmp_denoise"
 
     input:
-    tuple val(sample_id), path(fastq_qza)
+    tuple val(set_id), path(fastq_qza)
 
     output:
-    tuple val(sample_id), path("${sample_id}_table.qza"), path("${sample_id}_representative_sequences.qza"), emit: table_seqs
-    path "${sample_id}_denoising_stats.qza",    emit: stats
+    tuple val(set_id), path("${set_id}_table.qza"), path("${set_id}_representative_sequences.qza"), emit: table_seqs
+    path "${set_id}_denoising_stats.qza",    emit: stats
 
     script:
     if (params.read_type == "single")
@@ -34,9 +34,9 @@ process DENOISE_DADA2 {
             --p-n-threads ${params.dada2.num_threads} \
             --p-n-reads-learn ${params.dada2.num_reads_learn} \
             --p-hashed-feature-ids ${params.dada2.hashed_feature_ids} \
-            --o-table ${sample_id}_table.qza \
-            --o-representative-sequences ${sample_id}_representative_sequences.qza \
-            --o-denoising-stats ${sample_id}_denoising_stats.qza \
+            --o-table ${set_id}_table.qza \
+            --o-representative-sequences ${set_id}_representative_sequences.qza \
+            --o-denoising-stats ${set_id}_denoising_stats.qza \
             --verbose
         """
 
@@ -63,9 +63,9 @@ process DENOISE_DADA2 {
             --p-n-threads ${params.dada2.num_threads} \
             --p-n-reads-learn ${params.dada2.num_reads_learn} \
             --p-hashed-feature-ids ${params.dada2.hashed_feature_ids} \
-            --o-table ${sample_id}_table.qza \
-            --o-representative-sequences ${sample_id}_representative_sequences.qza \
-            --o-denoising-stats ${sample_id}_denoising_stats.qza \
+            --o-table ${set_id}_table.qza \
+            --o-representative-sequences ${set_id}_representative_sequences.qza \
+            --o-denoising-stats ${set_id}_denoising_stats.qza \
             --verbose
         """
 }

--- a/modules/get_sra_data.nf
+++ b/modules/get_sra_data.nf
@@ -1,11 +1,12 @@
 process GENERATE_ID_ARTIFACT {
     label "container_fondue"
+    tag "${set_id}"
 
     input:
-    path inp_id_file
+    tuple val(set_id), path(inp_id_file)
 
     output:
-    path "accession_id.qza"
+    tuple val(set_id), path("id.qza")
 
     script:
     """
@@ -14,21 +15,22 @@ process GENERATE_ID_ARTIFACT {
 
     qiime tools import \
         --input-path ${inp_id_file} \
-        --output-path accession_id.qza \
+        --output-path id.qza \
         --type 'NCBIAccessionIDs'
     """
 }
 
 process GET_SRA_DATA {
     label "container_fondue"
+    tag "${set_id}"
 
     input:
-    path id_qza
+    tuple val(set_id), path(id_qza)
 
     output:
-    path "sra_download/failed_runs.qza",  emit: failed
-    path "sra_download/paired_reads.qza", emit: paired
-    path "sra_download/single_reads.qza", emit: single
+    tuple val(set_id), path("sra_download/failed_runs.qza"),  emit: failed
+    tuple val(set_id), path("sra_download/paired_reads.qza"), emit: paired
+    tuple val(set_id), path("sra_download/single_reads.qza"), emit: single
 
     script:
     """
@@ -53,12 +55,13 @@ process GET_SRA_DATA {
 process IMPORT_FASTQ {
     label "container_qiime2"
     errorStrategy "ignore"
+    tag "${set_id}"
 
     input:
-    path fq_manifest
+    tuple val(set_id), path(fq_manifest)
 
     output:
-    path "sequences.qza"
+    tuple val(set_id), path("sequences.qza")
 
     script:
     read_type_upper = params.read_type.capitalize()
@@ -76,5 +79,25 @@ process IMPORT_FASTQ {
         --input-path ${fq_manifest} \
         --input-format ${read_type_upper}EndFastqManifestPhred${params.phred_offset}V2 \
         --output-path sequences.qza
+    """
+}
+
+process SPLIT_FASTQ_MANIFEST {
+    label "container_pandas"
+
+    input:
+    tuple val(set_id), path(fq_manifest)
+
+    output:
+    path "*${params.fastq_split.suffix}"
+
+    script:
+    """
+    echo 'Splitting FASTQ manifest to process FASTQ files individually...'
+    python ${workflow.projectDir}/bin/split_manifest.py \
+        --input_manifest ${fq_manifest} \
+        --output_dir . \
+        --suffix ${params.fastq_split.suffix} \
+        --split_method ${params.fastq_split.method}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -101,7 +101,7 @@ params {
     fastq_split {
         enabled = false
         suffix  = "_split.tsv"
-        method  = "sample"
+        method  = 10
     }
 
     taxa_level       = 5    // collapse to genus
@@ -123,9 +123,11 @@ params {
     fastqc_release         = "v0.11.9_cv8"
     fastqc_container       = "biocontainers/fastqc:${params.fastqc_release}"
     multiqc_release        = "v1.18"
-    multiqc_container      = "ewels/multiqc:${multiqc_release}"
+    multiqc_container      = "ewels/multiqc:${params.multiqc_release}"
     fondue_release         = "2023.2-ps"
-    fondue_container       = "linathekim/q2-fondue:${fondue_release}"
+    fondue_container       = "linathekim/q2-fondue:${params.fondue_release}"
+    pandas_release         = "1.4.2"
+    pandas_container       = "amancevice/pandas:${params.pandas_release}"
 }
 
 // Determine necessary QIIME 2 Conda envs to incorporate
@@ -140,6 +142,7 @@ params.qiime_conda_env   = "${baseDir}/assets/qiime2-2023.2-py38-${sys_abbreviat
 params.fondue_conda_env  = "${baseDir}/assets/q2-fondue-2023.2-${sys_abbreviation}.yml"
 params.fastqc_conda_env  = "bioconda::fastqc"
 params.multiqc_conda_env = "bioconda::multiqc typing-extensions"
+params.pandas_conda_env  = "pandas"
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -171,6 +174,9 @@ profiles {
             withLabel:container_multiqc {
                 conda = "${params.multiqc_conda_env}"
             }
+            withLabel:container_pandas {
+                conda = "${params.pandas_conda_env}"
+            }
         }
     }
 
@@ -195,6 +201,9 @@ profiles {
             }
             withLabel:container_multiqc {
                 container = "${params.multiqc_container}"
+            }
+            withLabel:container_pandas {
+                container = "${params.pandas_container}"
             }
         }
     }

--- a/validate_inputs/paramsValidator.nf
+++ b/validate_inputs/paramsValidator.nf
@@ -51,6 +51,15 @@ def assertParam(value, typeConstraints, rangeConstraints = null, errorMessage = 
     }
 }
 
+def validatePrimerSequence(String sequence, String name) {
+    if (sequence) { // Checks if sequence is not null or empty
+        def invalidChars = sequence.findAll { !it.matches("[ACGTURYSWKMBDHVN ]") } // Finds invalid characters
+        if (invalidChars) {
+            throw new ParameterValidationException("$name contains invalid characters. Only nucleotide codes ACGTURYSWKMBDHVN and spaces are allowed. Found: ${invalidChars.unique().join(', ')}")
+        }
+    }
+}
+
 // Define a method to validate parameters
 def validateParams(params) {
 
@@ -96,6 +105,28 @@ def validateParams(params) {
 	// Validation for cutadapt parameters //
 	////////////////////////////////////////
 	def cutadapt = params.cutadapt
+
+	// Validate Cutadapt primer parameters based on sequencing type
+	if (params.read_type == "single") {
+		// Single-end sequencing validation
+		if (params.cutadapt?.front) {
+			validatePrimerSequence(params.cutadapt.front, "cutadapt.front")
+		}
+		if (params.cutadapt?.front_f || params.cutadapt?.front_r) {
+			throw new ParameterValidationException("For single-end sequencing, only 'cutadapt.front' should be set, not 'cutadapt.front_f' or 'cutadapt.front_r'.")
+		}
+	} else if (params.read_type == "paired") {
+		// Paired-end sequencing validation
+		if (params.cutadapt?.front_f && params.cutadapt?.front_r) {
+			validatePrimerSequence(params.cutadapt.front_f, "cutadapt.front_f")
+			validatePrimerSequence(params.cutadapt.front_r, "cutadapt.front_r")
+		} else if ((!params.cutadapt?.front_f && params.cutadapt?.front_r) || (params.cutadapt?.front_f && !params.cutadapt?.front_r)) {
+			throw new ParameterValidationException("For paired-end sequencing, both 'cutadapt.front_f' and 'cutadapt.front_r' must be set.")
+		}
+		if (params.cutadapt?.front) {
+			throw new ParameterValidationException("For paired-end sequencing, 'cutadapt.front' cannot be set, to use cutadapt please set 'cutadapt.front_f' and 'cutadapt.front_r'.")
+		}
+	}
 
 	assertParam(cutadapt.num_cores, [Integer], null, "cutadapt.num_cores must be an Integer")
 	assertParam(cutadapt.error_rate, [BigDecimal, Integer], [{ it >= 0 && it <= 1 }], "cutadapt.error_rate must be a Float or Integer with a value between 0 and 1")

--- a/validate_inputs/paramsValidator.nf
+++ b/validate_inputs/paramsValidator.nf
@@ -87,11 +87,6 @@ def validateParams(params) {
 
     }
 
-    if (params.primer_file) {
-        validateTsvFile(params.primer_file)
-        validateTsvContents(params.primer_file, params.read_type == "paired" ? 3 : 2, validIdColumnNames)
-    }
-
 	} catch (AssertionError e) {
     println "TSV file content validation failed: ${e.message}"
     System.exit(1)

--- a/workflows/pipe_16s.nf
+++ b/workflows/pipe_16s.nf
@@ -196,7 +196,7 @@ workflow PIPE_16S {
                         .combine ( ch_primer_seqs )
         CUTADAPT_TRIM ( ch_to_trim )
         ch_to_denoise = CUTADAPT_TRIM.out.qza
-        ch_to_multiqc = CUTADAPT_TRIM.out.stats
+        ch_to_multiqc = CUTADAPT_TRIM.out.stats.collect()
     } else {
         ch_to_denoise = CHECK_FASTQ_TYPE.out.qza
                             .map { qza -> ["all", qza] }

--- a/workflows/pipe_16s_download.nf
+++ b/workflows/pipe_16s_download.nf
@@ -160,7 +160,7 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
                         .combine ( ch_primer_seqs )
         CUTADAPT_TRIM ( ch_to_trim )
         ch_to_denoise = CUTADAPT_TRIM.out.qza
-        ch_to_multiqc = CUTADAPT_TRIM.out.stats
+        ch_to_multiqc = CUTADAPT_TRIM.out.stats.collect()
     } else {
         ch_to_denoise = CHECK_FASTQ_TYPE.out.qza
                             .map { qza -> ["all", qza] }

--- a/workflows/pipe_16s_download.nf
+++ b/workflows/pipe_16s_download.nf
@@ -105,6 +105,7 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
         }
     } else {
         is_cutadapt_run = null
+    }
 
     // Determine whether reference downloads are necessary
     if (params.otu_ref_file) {

--- a/workflows/pipe_16s_download.nf
+++ b/workflows/pipe_16s_download.nf
@@ -24,7 +24,8 @@ include { validateParams } from '../validate_inputs/paramsValidator'
 */
 
 
-include { GENERATE_ID_ARTIFACT; GET_SRA_DATA; } from '../modules/get_sra_data'
+include { GENERATE_ID_ARTIFACT; GET_SRA_DATA;
+          SPLIT_FASTQ_MANIFEST                } from '../modules/get_sra_data'
 include { CHECK_FASTQ_TYPE; RUN_FASTQC;
           CUTADAPT_TRIM                       } from '../modules/quality_control'
 include { DENOISE_DADA2                       } from '../modules/denoise_dada2'
@@ -94,11 +95,16 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
 
     // INPUT AND VARIABLES
     // Determine whether Cutadapt will be run
-    if (params.primer_file) {
-        Channel.fromPath ( "${params.primer_file}", checkIfExists: true )
-            .splitCsv( sep: '\t', skip: 1 )
-            .set { ch_primer_seqs }
-    }
+    if (params.cutadapt.front) {
+        is_cutadapt_run = true
+    } else if (params.cutadapt.front_f) {
+        if (params.cutadapt.front_r) {
+            is_cutadapt_run = true
+        } else {
+            is_cutadapt_run = null
+        }
+    } else {
+        is_cutadapt_run = null
 
     // Determine whether reference downloads are necessary
     if (params.otu_ref_file) {
@@ -125,12 +131,22 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
         flag_get_classifier        = true
     }
 
-    // Start of the  Pipeline
+    // Pipeline start
     if (params.generate_input) {
         ch_inp_ids = Channel.fromPath ( "${params.inp_id_file}", checkIfExists: true )
+                        .map { [0, it] }
+        if (params.fastq_split.enabled == "True") {
+            SPLIT_FASTQ_MANIFEST ( ch_inp_ids )
+            manifest_suffix = ~/${params.fastq_split.suffix}/
+            ch_acc_ids = SPLIT_FASTQ_MANIFEST.out
+                                .flatten()
+                                .map { [(it.getName() - manifest_suffix), it] }
+        } else {
+            ch_acc_ids = ch_inp_ids
+        }
         
         // Download FASTQ files with q2-fondue
-        GENERATE_ID_ARTIFACT ( ch_inp_ids )
+        GENERATE_ID_ARTIFACT ( ch_acc_ids )
         GET_SRA_DATA         ( GENERATE_ID_ARTIFACT.out )
         
         if (params.read_type == "single") {
@@ -146,6 +162,7 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
         } else {
             Channel
                 .fromPath(params.input_artifact, checkIfExists: true)
+                .map { [0, it] }
                 .set { ch_sra_artifact }
         }
     }
@@ -155,15 +172,13 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
     CHECK_FASTQ_TYPE ( ch_sra_artifact )
     RUN_FASTQC ( CHECK_FASTQ_TYPE.out.fqs )
 
-    if (params.primer_file) {
+    if (is_cutadapt_run) {
         ch_to_trim = CHECK_FASTQ_TYPE.out.qza
-                        .combine ( ch_primer_seqs )
         CUTADAPT_TRIM ( ch_to_trim )
         ch_to_denoise = CUTADAPT_TRIM.out.qza
         ch_to_multiqc = CUTADAPT_TRIM.out.stats.collect()
     } else {
         ch_to_denoise = CHECK_FASTQ_TYPE.out.qza
-                            .map { qza -> ["all", qza] }
         ch_to_multiqc = "${projectDir}/assets/NO_FILE"
     }
     
@@ -171,7 +186,7 @@ workflow PIPE_16S_DOWNLOAD_INPUT {
     DENOISE_DADA2 ( ch_to_denoise )
     ch_denoised_qzas = DENOISE_DADA2.out.table_seqs
 
-    // Create multiqc reports
+    // Create MultiQC reports
     MULTIQC_STATS ( RUN_FASTQC.out, ch_to_multiqc )
 
     // Feature generation: Clustering

--- a/workflows/pipe_16s_import.nf
+++ b/workflows/pipe_16s_import.nf
@@ -156,7 +156,7 @@ workflow PIPE_16S_IMPORT_INPUT {
                         .combine ( ch_primer_seqs )
         CUTADAPT_TRIM ( ch_to_trim )
         ch_to_denoise = CUTADAPT_TRIM.out.qza
-        ch_to_multiqc = CUTADAPT_TRIM.out.stats
+        ch_to_multiqc = CUTADAPT_TRIM.out.stats.collect()
     } else {
         ch_to_denoise = CHECK_FASTQ_TYPE.out.qza
                             .map { qza -> ["all", qza] }


### PR DESCRIPTION
This PR introduces a change in the workflow code. Initially, in the code where we assigned `ch_to_multiqc = CUTADAPT_TRIM.out.stats`, the `MULTIQC_STATS` process did not wait for all the tasks of `CUTADAPT_TRIM` to complete. This resulted in only one log file from `CUTADAPT_TRIM` being present in the directory created for `MULTIQC_STATS`. Consequently, `MultiQC` considered only the log file generated from the first task. To resolve this issue, I simply needed to add .collect() to ensure that all tasks are completed before proceeding: `ch_to_multiqc = CUTADAPT_TRIM.out.stats.collect()`. This modification ensures that `MULTIQC_STATS` correctly waits for and includes all log files from `CUTADAPT_TRIM` tasks.